### PR TITLE
Optimizations made to DB.Get<T> and DB.Exists

### DIFF
--- a/DB.cs
+++ b/DB.cs
@@ -11,23 +11,20 @@ namespace BinaryRage
 {
 	static public class DB
 	{
-		static BlockingCollection<SimpleObject> sendQueue = new BlockingCollection<SimpleObject>();
+        static public void Insert<T>(string key, T value, string filelocation)
+        {
+            Interlocked.Increment(ref Cache.counter);
+            SimpleObject simpleObject = new SimpleObject { Key = key, Value = value, FileLocation = filelocation };
 
-		static public void Insert<T>(string key, T value, string filelocation)
-		{
-			Interlocked.Increment(ref Cache.counter);
-			SimpleObject simpleObject = new SimpleObject {Key = key, Value = value, FileLocation = filelocation};
-			
-			sendQueue.Add(simpleObject);
-			var data = sendQueue.Take(); //this blocks if there are no items in the queue.
+            //Add to cache
+            Cache.CacheDic[filelocation + key] = simpleObject;
 
-			//Add to cache
-			Cache.CacheDic[filelocation + key] = simpleObject;
-			ThreadPool.QueueUserWorkItem(state =>
-			{
-				Storage.WritetoStorage(data.Key, Compress.CompressGZip(ConvertHelper.ObjectToByteArray(value)), data.FileLocation);
-			});
-		}
+            ThreadPool.QueueUserWorkItem(state =>
+            {
+                SimpleObject data = (SimpleObject) state;
+                Storage.WritetoStorage(data.Key, Compress.CompressGZip(ConvertHelper.ObjectToByteArray(data.Value)), data.FileLocation);
+            }, simpleObject);
+        }
 
 		static public void Remove(string key, string filelocation)
 		{


### PR DESCRIPTION
Here is what I changed:
#### 1. 'DB.Get<T>'

DB.Get<T> changed to add the obtained value from 'disk' into the 'Cache', making subsequent 'Get<T>' calls for the same key more faster (or without IO).
#### 2. 'DB.Exist'

DB.Exist was changed to first check  the 'Cache' to avoid make unnecessary IO.
#### 3. 'DB.Insert<T>'

DB.Insert<T> was also changed to remove unnecessary code.
